### PR TITLE
For the asus rog ally: only fix TDP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ dependencies = [
  "sysinfo",
  "tokio",
  "tungstenite",
+ "users",
 ]
 
 [[package]]
@@ -1057,6 +1058,16 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ regex = "1"
 evdev = { version = "0.12.1", features = ["tokio", "serde"]}
 hyper = { version = "0.14", features = ["full"] }
 inotify = "0.10.1"
+users = "*"
 
 [profile.release]
 opt-level = "z"

--- a/src/devices/device_ally_tdp_only.rs
+++ b/src/devices/device_ally_tdp_only.rs
@@ -1,0 +1,61 @@
+use super::Device;
+use crate::devices::device_generic::DeviceGeneric;
+use crate::devices::Patch;
+use crate::server::SettingsRequest;
+use std::fs;
+use std::thread;
+use std::time::Duration;
+
+pub struct DeviceAllyTDPOnly {
+    device: DeviceGeneric,
+}
+
+impl DeviceAllyTDPOnly {
+    pub fn new() -> Self {
+        Self {
+            device: DeviceGeneric::new(30),
+        }
+    }
+}
+
+impl Device for DeviceAllyTDPOnly {
+    fn update_settings(&self, request: SettingsRequest) {
+        if let Some(per_app) = &request.per_app {
+            // TDP changes
+            if let Some(tdp) = per_app.tdp_limit {
+                self.set_tdp(tdp);
+            }
+        }
+    }
+
+    fn get_patches(&self) -> Vec<Patch> {
+        self.device.get_patches()
+    }
+
+    fn set_tdp(&self, tdp: i8) {
+        // Update thermal policy
+        let thermal_policy = match tdp {
+            val if val < 12 => 2,                 // silent
+            val if (12..=25).contains(&val) => 0, // performance
+            _ => 1,                               // turbo
+        };
+
+        println!("New Policy: {}", thermal_policy);
+
+        let file_path = "/sys/devices/platform/asus-nb-wmi/throttle_thermal_policy";
+        let _ = thread::spawn(move || match fs::read_to_string(file_path) {
+            Ok(content) if content.trim() != thermal_policy.to_string() => {
+                thread::sleep(Duration::from_millis(50));
+                fs::write(file_path, thermal_policy.to_string())
+                    .expect("Couldn't change thermal policy")
+            }
+            _ => {}
+        });
+
+        self.device.set_tdp(tdp);
+    }
+
+    fn get_key_mapper(&self) -> Option<tokio::task::JoinHandle<()>> {
+        self.device.get_key_mapper()
+    }
+}

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -1,8 +1,9 @@
 pub mod device_ally;
+pub mod device_ally_tdp_only;
 pub mod device_generic;
 
 use crate::{patch::Patch, server::SettingsRequest};
-use device_ally::DeviceAlly;
+use device_ally_tdp_only::DeviceAllyTDPOnly;
 use device_generic::DeviceGeneric;
 use regex::Regex;
 use std::fs;
@@ -20,7 +21,7 @@ pub fn create_device() -> Option<Box<dyn Device>> {
             match device_name.trim() {
                 // Asus Rog Ally
                 "AMD Ryzen Z1 Extreme ASUSTeK COMPUTER INC. RC71L" => {
-                    Some(Box::new(DeviceAlly::new()))
+                    Some(Box::new(DeviceAllyTDPOnly::new()))
                 }
 
                 // Ayaneo 2

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -1,12 +1,16 @@
 pub mod device_ally;
 pub mod device_ally_tdp_only;
 pub mod device_generic;
+use std::env;
 
 use crate::{patch::Patch, server::SettingsRequest};
 use device_ally_tdp_only::DeviceAllyTDPOnly;
 use device_generic::DeviceGeneric;
 use regex::Regex;
 use std::fs;
+use std::io::prelude::*;
+
+use self::device_ally::DeviceAlly;
 
 pub trait Device {
     fn update_settings(&self, request: SettingsRequest);
@@ -21,7 +25,38 @@ pub fn create_device() -> Option<Box<dyn Device>> {
             match device_name.trim() {
                 // Asus Rog Ally
                 "AMD Ryzen Z1 Extreme ASUSTeK COMPUTER INC. RC71L" => {
-                    Some(Box::new(DeviceAllyTDPOnly::new()))
+
+                return match env::home_dir() {
+                    Some(path) => match std::fs::File::open(path.join("steam-patch.conf")) {
+                        Ok(mut file) => {
+                            let mut contents: String = String::new();
+                            match file.read_to_string(&mut contents) {
+                                Ok(_result) => {
+                                    if contents.contains("native_input") {
+                                        Some(Box::new(DeviceAlly::new()))
+                                    } else {
+                                        println!("File ~/steam-patch.conf does NOT contains native_input. Using TDP control only.");
+                                        Some(Box::new(DeviceAllyTDPOnly::new()))
+                                    }
+                                },
+                                Err(_) => {
+                                    println!("Could not read file ~/steam-patch.conf");
+                                    Some(Box::new(DeviceAllyTDPOnly::new()))
+                                }
+                            }
+                        },
+                        Err(_) => {
+                            println!("Could not open file ~/steam-patch.conf");
+                            Some(Box::new(DeviceAllyTDPOnly::new()))
+                        }
+                    },
+                    None => {
+                        println!("Could not find home directory");
+                        Some(Box::new(DeviceAllyTDPOnly::new()))
+                    },
+                }
+
+                    
                 }
 
                 // Ayaneo 2

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,10 @@ pub fn get_username() -> String {
     let args: Vec<String> = env::args().collect();
 
     if args.len() != 2 {
-        return String::from("gamer");
+        return match users::get_current_username() {
+            Some(uname) => format!("{:?}", uname),
+            None        => String::from("gamer"),
+        }
     }
 
     let arg = &args[1];


### PR DESCRIPTION
handycon has had its showstopper bug solved, and in addition if the OSK keyboard is brought up face the steam button gets lost.

To solve both of these issues I propose an ally device that only allows for setting the TDP the way it used to do in DeviceAlly.

Maybe adding a configuration switch in a file is something I should do.... right? 