### PR TITLE
Fix keys on Ally BIOS 330

### DIFF
--- a/src/devices/device_ally.rs
+++ b/src/devices/device_ally.rs
@@ -82,7 +82,9 @@ pub fn pick_device() -> Option<evdev::Device> {
         let input_id = device.input_id();
 
         if input_id.vendor() == target_vendor_id && input_id.product() == target_product_id {
-            return Some(device);
+            if device.supported_keys().map_or(false, |keys| keys.contains(evdev::Key::KEY_PROG1)) {
+                return Some(device);
+            }
         }
     }
 


### PR DESCRIPTION
Several devices matching vendor_id and product_id of the N_KEYS keyboard are now being reported. We look for the right one checking if it supports (evdev::Key::KEY_PROG1)